### PR TITLE
Add GitHub

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
 		ForAllRubrics | <a href="https://github.com/forallrubrics/policies" alt="Link to terms" title="Link to terms">Link to terms</a>
 	</li>
 	<li>
+		GitHub | <a href="https://github.com/github/site-policy" alt="Link to terms" title="Link to terms">Link to terms</a>
+	</li>
+	<li>
 		Junyo | <a href="https://github.com/junyoed/policies" alt="Link to terms" title="Link to terms">Link to terms</a>
 	</li>
 	<li>


### PR DESCRIPTION
Great project!

GitHub's own site policies (terms of service, privacy, and several others) have been open source since July last year https://github.com/blog/2393-open-sourcing-our-site-policies-and-new-changes-to-our-terms-of-service (some of them were under an open license prior, but without a public repo for feedback and collaboration).